### PR TITLE
fixing upper-case vs lower-case include statement issue

### DIFF
--- a/nrf/applications/Riverrock/src/icm/icm42605/icm426xxActionDetect.c
+++ b/nrf/applications/Riverrock/src/icm/icm42605/icm426xxActionDetect.c
@@ -8,7 +8,7 @@
 #include "icm_chip_helper.h"
 #include "modem/modem_helper.h"
 #include "nvs/local_storage.h"
-#include "icm42605/Icm426xxActionDetect.h"
+#include "icm42605/icm426xxActionDetect.h"
 
 extern int tiltConf(void);
 extern int womConf(void);

--- a/nrf/applications/Riverrock/src/icm/icm42605/icm426xx_pedometer.c
+++ b/nrf/applications/Riverrock/src/icm/icm42605/icm426xx_pedometer.c
@@ -10,7 +10,7 @@
 #include "modem/modem_helper.h"
 #include "nvs/local_storage.h"
 #include "icm42605/Icm426xxDriver_HL_apex.h"
-#include "icm42605/Icm426xx_pedometer.h"
+#include "icm42605/icm426xx_pedometer.h"
 
 LOG_MODULE_REGISTER(pedometer, CONFIG_ASSET_TRACKER_LOG_LEVEL);
 


### PR DESCRIPTION
This fixes the build errors, such as 

```
/app/pebble-firmware/nrf/applications/Riverrock/src/icm/icm42605/icm426xx_pedometer.c:13:10: fatal error: icm42605/Icm426xx_pedometer.h: No such file or directory
pebble-firmware    |    13 | #include "icm42605/Icm426xx_pedometer.h"
```